### PR TITLE
Set max_jobs = 50 for macos compatibility

### DIFF
--- a/lua/core/pack.lua
+++ b/lua/core/pack.lua
@@ -35,6 +35,7 @@ function Packer:load_packer()
         git = { clone_timeout = 120 },
         disable_commands = true,
         display = display,
+        max_jobs = 50,
     })
     packer.reset()
     local use = packer.use


### PR DESCRIPTION
The default config makes PackerInstall/Sync freeze up unless you set this config value [as recommended in this packer.nvim issue](https://github.com/wbthomason/packer.nvim/issues/202).